### PR TITLE
Update package dependencies for Python

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,9 +8,13 @@ Build-Depends: debhelper (>= 7.0.50),
  python-support,
  univention-config-dev,
  python-all,
- python-support (>= 0.90),
  gettext,
- gnupg2
+ gnupg2,
+ dh-python,
+ python-debian,
+ python3-debian,
+ python3-all,
+ univention-management-console-dev (>= 11.0.4-37)
 XS-Python-Version: 2.6, 2.7
 
 Package: kopano4ucs-lib

--- a/debian/control
+++ b/debian/control
@@ -13,8 +13,7 @@ Build-Depends: debhelper (>= 7.0.50),
  dh-python,
  python-debian,
  python3-debian,
- python3-all,
- univention-management-console-dev (>= 11.0.4-37)
+ python3-all
 XS-Python-Version: 2.6, 2.7
 
 Package: kopano4ucs-lib

--- a/debian/control
+++ b/debian/control
@@ -11,9 +11,7 @@ Build-Depends: debhelper (>= 7.0.50),
  gettext,
  gnupg2,
  dh-python,
- python-debian,
- python3-debian,
- python3-all
+ python-debian
 XS-Python-Version: 2.6, 2.7
 
 Package: kopano4ucs-lib

--- a/debian/rules
+++ b/debian/rules
@@ -48,4 +48,4 @@ override_dh_gencontrol:
 	dh_gencontrol -- $(SUBSTVARS)
 
 %:
-	dh $@ --with python_support
+	dh $@ --with python2

--- a/docs/building.md
+++ b/docs/building.md
@@ -4,6 +4,6 @@ To have access to the UCS linter these packages should be build on directly on a
 
 The following command performs a local build through the osc command line client and puts the resulting packages into the current directory:
 
-```
-$ osc build Univention_4.3 kopano4ucs.dsc -k .
+```bash
+$ osc build Univention_4.4 kopano4ucs.dsc -k .
 ```

--- a/docs/building.md
+++ b/docs/building.md
@@ -7,3 +7,9 @@ The following command performs a local build through the osc command line client
 ```bash
 $ osc build Univention_4.4 kopano4ucs.dsc -k .
 ```
+
+## Copy local state to https://build.opensuse.org/
+
+```bash
+osc copypac -t https://api.opensuse.org kopano4ucs kopano4ucs home:zfbartels kopano4ucs
+```

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,6 +1,6 @@
 # Building Kopano4UCS
 
-To have access to the UCS linter these packages should be build on directly on an UCS system. The easist way for a third party to do this us utilising the [openSUSE Build Service](https://build.opensuse.org).  An example project which can be "branched" is https://build.opensuse.org/package/show/home:zfbartels/kopano4ucs.
+To have access to the UCS linter these packages should be build on directly on an UCS system. The easiest way for a third party to do this us utilizing the [openSUSE Build Service](https://build.opensuse.org).  An example project which can be "branched" is https://build.opensuse.org/package/show/home:zfbartels/kopano4ucs.
 
 The following command performs a local build through the osc command line client and puts the resulting packages into the current directory:
 


### PR DESCRIPTION
With this at least a `osc build Univention_4.4 kopano4ucs.dsc -k .` succeeds. Further packaging changes like depending on `univention-management-console-dev(>= 11.0.4-37)` or `python3-` variants fails, as these are not available in the obs target for ucs 4.4 (and a 5.0 target seemingly does not exist).